### PR TITLE
Implement Diagnosis DAO and fix condition type check

### DIFF
--- a/api/src/main/java/org/openmrs/module/fhir2/api/dao/impl/FhirDiagnosisDaoImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/dao/impl/FhirDiagnosisDaoImpl.java
@@ -1,0 +1,46 @@
+package org.openmrs.module.fhir2.api.dao.impl;
+
+import ca.uhn.fhir.rest.param.ReferenceAndListParam;
+import ca.uhn.fhir.rest.param.TokenAndListParam;
+import org.hibernate.Criteria;
+import org.openmrs.Diagnosis;
+import org.openmrs.module.fhir2.FhirConstants;
+import org.openmrs.module.fhir2.api.dao.FhirDiagnosisDao;
+import org.openmrs.module.fhir2.api.search.param.SearchParameterMap;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FhirDiagnosisDaoImpl extends BaseFhirDao<Diagnosis> implements FhirDiagnosisDao {
+
+    @Override
+    public boolean hasDistinctResults() {
+        return false;
+    }
+
+    @Override
+    protected void setupSearchParams(Criteria criteria, SearchParameterMap theParams) {
+        theParams.getParameters().forEach(entry -> {
+            switch (entry.getKey()) {
+                case FhirConstants.PATIENT_REFERENCE_SEARCH_HANDLER:
+                    entry.getValue().forEach(param -> handlePatientReference(criteria, (ReferenceAndListParam) param.getParam(), "patient"));
+                    break;
+                case FhirConstants.ENCOUNTER_REFERENCE_SEARCH_HANDLER:
+                    entry.getValue().forEach(param -> handleEncounterReference(criteria, (ReferenceAndListParam) param.getParam(), "encounter"));
+                    break;
+                case FhirConstants.CODED_SEARCH_HANDLER:
+                    entry.getValue().forEach(param -> handleDiagnosisCode(criteria, (TokenAndListParam) param.getParam()));
+                    break;
+                case FhirConstants.COMMON_SEARCH_HANDLER:
+                    handleCommonSearchParameters(entry.getValue()).ifPresent(criteria::add);
+                    break;
+            }
+        });
+    }
+
+    private void handleDiagnosisCode(Criteria criteria, TokenAndListParam code) {
+        if (code != null) {
+            criteria.createAlias("diagnosis.coded", "cd");
+            handleCodeableConcept(criteria, code, "cd", "map", "term").ifPresent(criteria::add);
+        }
+    }
+}

--- a/api/src/main/java/org/openmrs/module/fhir2/api/util/FhirUtils.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/util/FhirUtils.java
@@ -147,14 +147,16 @@ public class FhirUtils {
 		}
 	}
 
-	public static Optional<OpenmrsConditionType> getOpenmrsConditionType(Condition condition) {
-		if(condition.hasCategory() && condition.getCategory().get(0).hasCoding()
-		&& condition.getCategoryFirstRep().getCodingFirstRep().equals("encounter-diagnosis")) {
-			return Optional.of(OpenmrsConditionType.DIAGNOSIS);
-		} else {
-			return Optional.of(OpenmrsConditionType.CONDITION);
-		}
-	}
+       public static Optional<OpenmrsConditionType> getOpenmrsConditionType(Condition condition) {
+               if (condition.hasCategory() && condition.getCategoryFirstRep().hasCoding()) {
+                       String code = condition.getCategoryFirstRep().getCodingFirstRep().getCode();
+                       if ("encounter-diagnosis".equals(code)) {
+                               return Optional.of(OpenmrsConditionType.DIAGNOSIS);
+                       }
+               }
+
+               return Optional.of(OpenmrsConditionType.CONDITION);
+       }
 	
 	/**
 	 * Provides implementation-defined localizations for OpenMRS Metadata. This should be used in any

--- a/api/src/test/java/org/openmrs/module/fhir2/api/dao/impl/FhirDiagnosisDaoImpl_Test.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/dao/impl/FhirDiagnosisDaoImpl_Test.java
@@ -1,0 +1,47 @@
+package org.openmrs.module.fhir2.api.dao.impl;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+import org.hibernate.SessionFactory;
+import org.junit.Before;
+import org.junit.Test;
+import org.openmrs.Diagnosis;
+import org.openmrs.api.PatientService;
+import org.openmrs.module.fhir2.BaseFhirContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+public class FhirDiagnosisDaoImpl_Test extends BaseFhirContextSensitiveTest {
+
+    private static final String DIAGNOSIS_UUID = "11111111-2222-3333-4444-555555555555";
+
+    @Autowired
+    @Qualifier("sessionFactory")
+    private SessionFactory sessionFactory;
+
+    @Autowired
+    private PatientService patientService;
+
+    private FhirDiagnosisDaoImpl dao;
+
+    @Before
+    public void setUp() {
+        dao = new FhirDiagnosisDaoImpl();
+        dao.setSessionFactory(sessionFactory);
+    }
+
+    @Test
+    public void createOrUpdate_shouldSaveDiagnosis() {
+        Diagnosis diagnosis = new Diagnosis();
+        diagnosis.setUuid(DIAGNOSIS_UUID);
+        diagnosis.setPatient(patientService.getPatient(2));
+
+        dao.createOrUpdate(diagnosis);
+
+        Diagnosis result = dao.get(DIAGNOSIS_UUID);
+        assertThat(result, notNullValue());
+        assertThat(result.getUuid(), equalTo(DIAGNOSIS_UUID));
+    }
+}

--- a/api/src/test/java/org/openmrs/module/fhir2/api/util/FhirUtilsTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/util/FhirUtilsTest.java
@@ -1,0 +1,38 @@
+package org.openmrs.module.fhir2.api.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+import java.util.Optional;
+
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Condition;
+import org.junit.Test;
+
+public class FhirUtilsTest {
+
+    @Test
+    public void getOpenmrsConditionType_shouldIdentifyDiagnosis() {
+        Condition condition = new Condition();
+        CodeableConcept category = new CodeableConcept();
+        category.addCoding(new Coding("http://terminology.hl7.org/CodeSystem/condition-category", "encounter-diagnosis", null));
+        condition.addCategory(category);
+
+        Optional<FhirUtils.OpenmrsConditionType> result = FhirUtils.getOpenmrsConditionType(condition);
+
+        assertThat(result.isPresent(), equalTo(true));
+        assertThat(result.get(), equalTo(FhirUtils.OpenmrsConditionType.DIAGNOSIS));
+    }
+
+    @Test
+    public void getOpenmrsConditionType_shouldDefaultToCondition() {
+        Condition condition = new Condition();
+
+        Optional<FhirUtils.OpenmrsConditionType> result = FhirUtils.getOpenmrsConditionType(condition);
+
+        assertThat(result.isPresent(), equalTo(true));
+        assertThat(result.get(), equalTo(FhirUtils.OpenmrsConditionType.CONDITION));
+    }
+}


### PR DESCRIPTION
## Summary
- add `FhirDiagnosisDaoImpl` and register as a component
- fix `FhirUtils.getOpenmrsConditionType` to check coding code
- test diagnosis DAO basic save/get
- add unit tests for condition type detection

## Testing
- `mvn -q test` *(fails: `bash: command not found: mvn`)*

------
https://chatgpt.com/codex/tasks/task_e_68798f0d84b88324bdee88bd8c94fed7