### PR TITLE
Add diagnosis code search tests

### DIFF
--- a/api/src/test/java/org/openmrs/module/fhir2/providers/r3/ConditionFhirR3ResourceProviderTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/providers/r3/ConditionFhirR3ResourceProviderTest.java
@@ -201,7 +201,7 @@ public class ConditionFhirR3ResourceProviderTest extends BaseFhirR3ProvenanceRes
 	}
 	
 	@Test
-	public void searchConditions_shouldReturnConditionReturnedByServiceWhenPatientIsNull() {
+        public void searchConditions_shouldReturnConditionReturnedByServiceWhenPatientIsNull() {
 		ReferenceAndListParam subjectReference = new ReferenceAndListParam();
 		subjectReference.addValue(new ReferenceOrListParam().add(new ReferenceParam(Patient.SP_GIVEN, "subject name")));
 		
@@ -240,6 +240,95 @@ public class ConditionFhirR3ResourceProviderTest extends BaseFhirR3ProvenanceRes
 		
 		assertThat(result, notNullValue());
 		assertThat(resultList, hasSize(greaterThanOrEqualTo(1)));
-		assertThat(resultList.get(0).fhirType(), equalTo(FhirConstants.CONDITION));
-	}
+                assertThat(resultList.get(0).fhirType(), equalTo(FhirConstants.CONDITION));
+        }
+
+       @Test
+       public void searchDiagnoses_shouldReturnDiagnosisReturnedByService() {
+               ReferenceAndListParam patientReference = new ReferenceAndListParam();
+               patientReference.addValue(new ReferenceOrListParam().add(new ReferenceParam(Patient.SP_GIVEN, "patient name")));
+
+               ReferenceAndListParam subjectReference = new ReferenceAndListParam();
+               subjectReference.addValue(new ReferenceOrListParam().add(new ReferenceParam(Patient.SP_GIVEN, "subject name")));
+
+               TokenAndListParam codeList = new TokenAndListParam();
+               codeList.addValue(new TokenOrListParam().add(new TokenParam("test code")));
+
+               TokenAndListParam clinicalList = new TokenAndListParam();
+               clinicalList.addValue(new TokenOrListParam().add(new TokenParam("test clinical")));
+
+               DateRangeParam onsetDate = new DateRangeParam().setLowerBound("gt2020-05-01").setUpperBound("lt2021-05-01");
+
+               QuantityAndListParam onsetAge = new QuantityAndListParam();
+               onsetAge.addValue(new QuantityOrListParam().add(new QuantityParam(12)));
+
+               DateRangeParam recordDate = new DateRangeParam().setLowerBound("gt2020-05-01").setUpperBound("lt2021-05-01");
+
+               TokenAndListParam tag = new TokenAndListParam()
+                               .addAnd(new TokenOrListParam().add(FhirConstants.OPENMRS_FHIR_EXT_CONDITION_TAG, "encounter-diagnosis"));
+
+               TokenAndListParam uuid = new TokenAndListParam().addAnd(new TokenParam(CONDITION_UUID));
+
+               DateRangeParam lastUpdated = new DateRangeParam().setLowerBound(LAST_UPDATED_DATE).setUpperBound(LAST_UPDATED_DATE);
+
+               SortSpec sort = new SortSpec("sort param");
+
+               HashSet<Include> includes = new HashSet<>();
+
+               when(conditionService.searchConditions(new ConditionSearchParams(patientReference, codeList, clinicalList, onsetDate,
+                               onsetAge, recordDate, tag, uuid, lastUpdated, sort, null)))
+                               .thenReturn(new MockIBundleProvider<>(Collections.singletonList(condition), 10, 1));
+
+               IBundleProvider result = resourceProvider.searchConditions(patientReference, subjectReference, codeList,
+                               clinicalList, onsetDate, onsetAge, recordDate, tag, uuid, lastUpdated, sort, includes);
+
+               List<Condition> resultList = get(result);
+
+               assertThat(result, notNullValue());
+               assertThat(resultList, hasSize(greaterThanOrEqualTo(1)));
+               assertThat(resultList.get(0).fhirType(), equalTo(FhirConstants.CONDITION));
+       }
+
+       @Test
+       public void searchDiagnoses_shouldReturnDiagnosisReturnedByServiceWhenPatientIsNull() {
+               ReferenceAndListParam subjectReference = new ReferenceAndListParam();
+               subjectReference.addValue(new ReferenceOrListParam().add(new ReferenceParam(Patient.SP_GIVEN, "subject name")));
+
+               TokenAndListParam codeList = new TokenAndListParam();
+               codeList.addValue(new TokenOrListParam().add(new TokenParam("test code")));
+
+               TokenAndListParam clinicalList = new TokenAndListParam();
+               clinicalList.addValue(new TokenOrListParam().add(new TokenParam("test clinical")));
+
+               DateRangeParam onsetDate = new DateRangeParam().setLowerBound("gt2020-05-01").setUpperBound("lt2021-05-01");
+
+               QuantityAndListParam onsetAge = new QuantityAndListParam();
+               onsetAge.addValue(new QuantityOrListParam().add(new QuantityParam(12)));
+
+               DateRangeParam recordDate = new DateRangeParam().setLowerBound("gt2020-05-01").setUpperBound("lt2021-05-01");
+
+               TokenAndListParam tag = new TokenAndListParam()
+                               .addAnd(new TokenOrListParam().add(FhirConstants.OPENMRS_FHIR_EXT_CONDITION_TAG, "encounter-diagnosis"));
+
+               TokenAndListParam uuid = new TokenAndListParam().addAnd(new TokenParam(CONDITION_UUID));
+
+               DateRangeParam lastUpdated = new DateRangeParam().setLowerBound(LAST_UPDATED_DATE).setUpperBound(LAST_UPDATED_DATE);
+
+               SortSpec sort = new SortSpec("sort param");
+
+               HashSet<Include> includes = new HashSet<>();
+
+               when(conditionService.searchConditions(new ConditionSearchParams(subjectReference, codeList, clinicalList, onsetDate,
+                               onsetAge, recordDate, tag, uuid, lastUpdated, sort, null)))
+                               .thenReturn(new MockIBundleProvider<>(Collections.singletonList(condition), 10, 1));
+
+               IBundleProvider result = resourceProvider.searchConditions(subjectReference, subjectReference, codeList,
+                               clinicalList, onsetDate, onsetAge, recordDate, tag, uuid, lastUpdated, sort, includes);
+
+               List<Condition> resultList = get(result);
+
+               assertThat(result, notNullValue());
+               assertThat(resultList, hasSize(greaterThanOrEqualTo(1)));
+               assertThat(resultList.get(0).fhirType(), equalTo(FhirConstants.CONDITION));
+       }
 }

--- a/api/src/test/java/org/openmrs/module/fhir2/providers/r4/ConditionFhirResourceProviderTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/providers/r4/ConditionFhirResourceProviderTest.java
@@ -148,7 +148,7 @@ public class ConditionFhirResourceProviderTest extends BaseFhirProvenanceResourc
 	}
 	
 	@Test
-	public void searchConditions_shouldReturnConditionReturnedByService() {
+        public void searchConditions_shouldReturnConditionReturnedByService() {
 		ReferenceAndListParam patientReference = new ReferenceAndListParam();
 		patientReference.addValue(new ReferenceOrListParam().add(new ReferenceParam(Patient.SP_GIVEN, "patient name")));
 		
@@ -194,7 +194,7 @@ public class ConditionFhirResourceProviderTest extends BaseFhirProvenanceResourc
 	}
 	
 	@Test
-	public void searchConditions_shouldReturnConditionReturnedByServiceWhenPatientIsNull() {
+        public void searchConditions_shouldReturnConditionReturnedByServiceWhenPatientIsNull() {
 		ReferenceAndListParam subjectReference = new ReferenceAndListParam();
 		subjectReference.addValue(new ReferenceOrListParam().add(new ReferenceParam(Patient.SP_GIVEN, "subject name")));
 		
@@ -233,6 +233,95 @@ public class ConditionFhirResourceProviderTest extends BaseFhirProvenanceResourc
 		
 		assertThat(result, notNullValue());
 		assertThat(resultList, hasSize(greaterThanOrEqualTo(1)));
-		assertThat(resultList.iterator().next().fhirType(), equalTo(FhirConstants.CONDITION));
-	}
+                assertThat(resultList.iterator().next().fhirType(), equalTo(FhirConstants.CONDITION));
+        }
+
+       @Test
+       public void searchDiagnoses_shouldReturnDiagnosisReturnedByService() {
+               ReferenceAndListParam patientReference = new ReferenceAndListParam();
+               patientReference.addValue(new ReferenceOrListParam().add(new ReferenceParam(Patient.SP_GIVEN, "patient name")));
+
+               ReferenceAndListParam subjectReference = new ReferenceAndListParam();
+               subjectReference.addValue(new ReferenceOrListParam().add(new ReferenceParam(Patient.SP_GIVEN, "subject name")));
+
+               TokenAndListParam codeList = new TokenAndListParam();
+               codeList.addValue(new TokenOrListParam().add(new TokenParam("test code")));
+
+               TokenAndListParam clinicalList = new TokenAndListParam();
+               clinicalList.addValue(new TokenOrListParam().add(new TokenParam("test clinical")));
+
+               DateRangeParam onsetDate = new DateRangeParam().setLowerBound("gt2020-05-01").setUpperBound("lt2021-05-01");
+
+               QuantityAndListParam onsetAge = new QuantityAndListParam();
+               onsetAge.addValue(new QuantityOrListParam().add(new QuantityParam(12)));
+
+               DateRangeParam recordDate = new DateRangeParam().setLowerBound("gt2020-05-01").setUpperBound("lt2021-05-01");
+
+                TokenAndListParam tag = new TokenAndListParam()
+                                .addAnd(new TokenOrListParam().add(FhirConstants.OPENMRS_FHIR_EXT_CONDITION_TAG, "encounter-diagnosis"));
+
+               TokenAndListParam uuid = new TokenAndListParam().addAnd(new TokenParam(CONDITION_UUID));
+
+               DateRangeParam lastUpdated = new DateRangeParam().setLowerBound(LAST_UPDATED_DATE).setUpperBound(LAST_UPDATED_DATE);
+
+               SortSpec sort = new SortSpec("sort param");
+
+               HashSet<Include> includes = new HashSet<>();
+
+               when(conditionService.searchConditions(new ConditionSearchParams(patientReference, codeList, clinicalList, onsetDate,
+                               onsetAge, recordDate, tag, uuid, lastUpdated, sort, null)))
+                               .thenReturn(new MockIBundleProvider<>(Collections.singletonList(condition), 10, 1));
+
+               IBundleProvider result = resourceProvider.searchConditions(patientReference, subjectReference, codeList,
+                               clinicalList, onsetDate, onsetAge, recordDate, tag, uuid, lastUpdated, sort, includes);
+
+               List<IBaseResource> resultList = get(result);
+
+               assertThat(result, notNullValue());
+               assertThat(resultList, hasSize(greaterThanOrEqualTo(1)));
+               assertThat(resultList.iterator().next().fhirType(), equalTo(FhirConstants.CONDITION));
+       }
+
+       @Test
+       public void searchDiagnoses_shouldReturnDiagnosisReturnedByServiceWhenPatientIsNull() {
+               ReferenceAndListParam subjectReference = new ReferenceAndListParam();
+               subjectReference.addValue(new ReferenceOrListParam().add(new ReferenceParam(Patient.SP_GIVEN, "subject name")));
+
+               TokenAndListParam codeList = new TokenAndListParam();
+               codeList.addValue(new TokenOrListParam().add(new TokenParam("test code")));
+
+               TokenAndListParam clinicalList = new TokenAndListParam();
+               clinicalList.addValue(new TokenOrListParam().add(new TokenParam("test clinical")));
+
+               DateRangeParam onsetDate = new DateRangeParam().setLowerBound("gt2020-05-01").setUpperBound("lt2021-05-01");
+
+               QuantityAndListParam onsetAge = new QuantityAndListParam();
+               onsetAge.addValue(new QuantityOrListParam().add(new QuantityParam(12)));
+
+               DateRangeParam recordDate = new DateRangeParam().setLowerBound("gt2020-05-01").setUpperBound("lt2021-05-01");
+
+               TokenAndListParam tag = new TokenAndListParam()
+                               .addAnd(new TokenOrListParam().add(FhirConstants.OPENMRS_FHIR_EXT_CONDITION_TAG, "encounter-diagnosis"));
+
+               TokenAndListParam uuid = new TokenAndListParam().addAnd(new TokenParam(CONDITION_UUID));
+
+               DateRangeParam lastUpdated = new DateRangeParam().setLowerBound(LAST_UPDATED_DATE).setUpperBound(LAST_UPDATED_DATE);
+
+               SortSpec sort = new SortSpec("sort param");
+
+               HashSet<Include> includes = new HashSet<>();
+
+               when(conditionService.searchConditions(new ConditionSearchParams(subjectReference, codeList, clinicalList, onsetDate,
+                               onsetAge, recordDate, tag, uuid, lastUpdated, sort, null)))
+                               .thenReturn(new MockIBundleProvider<>(Collections.singletonList(condition), 10, 1));
+
+               IBundleProvider result = resourceProvider.searchConditions(subjectReference, subjectReference, codeList,
+                               clinicalList, onsetDate, onsetAge, recordDate, tag, uuid, lastUpdated, sort, includes);
+
+               List<IBaseResource> resultList = get(result);
+
+               assertThat(result, notNullValue());
+               assertThat(resultList, hasSize(greaterThanOrEqualTo(1)));
+               assertThat(resultList.iterator().next().fhirType(), equalTo(FhirConstants.CONDITION));
+       }
 }


### PR DESCRIPTION
## Summary
- expand ConditionFhirResourceProviderTest with diagnosis tag search tests for R4
- add equivalent diagnosis tag search tests for R3 provider
- update tag value to use `encounter-diagnosis`

## Testing
- `mvn -pl api -am -Dtest=ConditionFhirResourceProviderTest,ConditionFhirR3ResourceProviderTest test` *(fails: Unresolveable build extension)*

------
https://chatgpt.com/codex/tasks/task_e_68803df81c688324b8a7cbb5c9ecdb46