### PR TITLE
Add unit tests for services and utilities

### DIFF
--- a/api/src/test/java/org/openmrs/module/fhir2/api/dao/impl/FhirDiagnosisDaoImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/dao/impl/FhirDiagnosisDaoImplTest.java
@@ -13,6 +13,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
+import org.hibernate.Criteria;
 import org.hibernate.SessionFactory;
 import org.junit.Before;
 import org.junit.Test;
@@ -21,8 +22,12 @@ import org.openmrs.Encounter;
 import org.openmrs.api.EncounterService;
 import org.openmrs.api.PatientService;
 import org.openmrs.module.fhir2.BaseFhirContextSensitiveTest;
+import org.openmrs.module.fhir2.FhirConstants;
+import org.openmrs.module.fhir2.api.search.param.SearchParameterMap;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import ca.uhn.fhir.rest.param.ReferenceAndListParam;
+import ca.uhn.fhir.rest.param.TokenAndListParam;
 
 public class FhirDiagnosisDaoImplTest extends BaseFhirContextSensitiveTest {
 	
@@ -57,8 +62,22 @@ public class FhirDiagnosisDaoImplTest extends BaseFhirContextSensitiveTest {
 		
 		dao.createOrUpdate(diagnosis);
 		
-		Diagnosis result = dao.get(DIAGNOSIS_UUID);
-		assertThat(result, notNullValue());
-		assertThat(result.getUuid(), equalTo(DIAGNOSIS_UUID));
-	}
-}
+        Diagnosis result = dao.get(DIAGNOSIS_UUID);
+        assertThat(result, notNullValue());
+        assertThat(result.getUuid(), equalTo(DIAGNOSIS_UUID));
+    }
+
+    @Test
+    public void hasDistinctResults_shouldReturnFalse() {
+        assertThat(dao.hasDistinctResults(), equalTo(false));
+    }
+
+    @Test
+    public void setupSearchParams_shouldHandleEmptyParams() {
+        Criteria criteria = sessionFactory.getCurrentSession().createCriteria(Diagnosis.class);
+        SearchParameterMap params = new SearchParameterMap()
+                .addParameter(FhirConstants.PATIENT_REFERENCE_SEARCH_HANDLER, new ReferenceAndListParam())
+                .addParameter(FhirConstants.CODED_SEARCH_HANDLER, new TokenAndListParam());
+        dao.setupSearchParams(criteria, params);
+        assertThat(criteria, notNullValue());
+    }

--- a/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirConditionServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirConditionServiceImplTest.java
@@ -38,6 +38,8 @@ import ca.uhn.fhir.rest.param.ReferenceParam;
 import ca.uhn.fhir.rest.param.TokenAndListParam;
 import ca.uhn.fhir.rest.param.TokenOrListParam;
 import ca.uhn.fhir.rest.param.TokenParam;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import org.hl7.fhir.instance.model.api.IBaseResource;
@@ -281,6 +283,37 @@ public class FhirConditionServiceImplTest {
 		
 		assertThat(result, notNullValue());
 		assertThat(resultList, not(empty()));
-		assertThat(resultList, hasSize(greaterThanOrEqualTo(1)));
-	}
+                assertThat(resultList, hasSize(greaterThanOrEqualTo(1)));
+        }
+
+
+        @Test
+        public void create_shouldDelegateToDiagnosisServiceForDiagnosis() {
+                org.hl7.fhir.r4.model.Condition condition = new org.hl7.fhir.r4.model.Condition();
+                CodeableConcept category = new CodeableConcept();
+                category.addCoding(new Coding("http://terminology.hl7.org/CodeSystem/condition-category", "encounter-diagnosis", null));
+                condition.addCategory(category);
+
+                org.hl7.fhir.r4.model.Condition expected = new org.hl7.fhir.r4.model.Condition();
+                when(diagnosisService.create(condition)).thenReturn(expected);
+
+                org.hl7.fhir.r4.model.Condition result = conditionService.create(condition);
+                assertThat(result, equalTo(expected));
+        }
+
+        @Test
+        public void update_shouldDelegateToDiagnosisServiceForDiagnosis() {
+                org.hl7.fhir.r4.model.Condition condition = new org.hl7.fhir.r4.model.Condition();
+                condition.setId(CONDITION_UUID);
+                CodeableConcept category = new CodeableConcept();
+                category.addCoding(new Coding("http://terminology.hl7.org/CodeSystem/condition-category", "encounter-diagnosis", null));
+                condition.addCategory(category);
+
+                org.hl7.fhir.r4.model.Condition expected = new org.hl7.fhir.r4.model.Condition();
+                when(diagnosisService.update(CONDITION_UUID, condition)).thenReturn(expected);
+
+                org.hl7.fhir.r4.model.Condition result = conditionService.update(CONDITION_UUID, condition);
+                assertThat(result, equalTo(expected));
+        }
+
 }

--- a/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirDiagnosisServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirDiagnosisServiceImplTest.java
@@ -1,0 +1,58 @@
+package org.openmrs.module.fhir2.api.impl;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import org.hl7.fhir.r4.model.Condition;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openmrs.Diagnosis;
+import org.openmrs.module.fhir2.api.dao.FhirDiagnosisDao;
+import org.openmrs.module.fhir2.api.search.SearchQuery;
+import org.openmrs.module.fhir2.api.search.SearchQueryInclude;
+import org.openmrs.module.fhir2.api.search.param.SearchParameterMap;
+import org.openmrs.module.fhir2.api.translators.DiagnosisTranslator;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FhirDiagnosisServiceImplTest {
+
+    @Mock
+    private FhirDiagnosisDao dao;
+    @Mock
+    private DiagnosisTranslator translator;
+    @Mock
+    private SearchQueryInclude<Condition> searchQueryInclude;
+    @Mock
+    private SearchQuery<Diagnosis, Condition, FhirDiagnosisDao, DiagnosisTranslator, SearchQueryInclude<Condition>> searchQuery;
+
+    private FhirDiagnosisServiceImpl diagnosisService;
+
+    @Before
+    public void setup() {
+        diagnosisService = new FhirDiagnosisServiceImpl() {
+            @Override
+            protected void validateObject(Diagnosis object) {
+            }
+        };
+        diagnosisService.setDao(dao);
+        diagnosisService.setTranslator(translator);
+        diagnosisService.setSearchQuery(searchQuery);
+        diagnosisService.setSearchQueryInclude(searchQueryInclude);
+    }
+
+    @Test
+    public void searchDiagnoses_shouldDelegateToSearchQuery() {
+        SearchParameterMap params = new SearchParameterMap();
+        IBundleProvider provider = mock(IBundleProvider.class);
+        when(searchQuery.getQueryResults(params, dao, translator, searchQueryInclude)).thenReturn(provider);
+
+        IBundleProvider result = diagnosisService.searchDiagnoses(params);
+        assertThat(result, equalTo(provider));
+    }
+}

--- a/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/DiagnosisTranslatorImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/DiagnosisTranslatorImplTest.java
@@ -1,0 +1,82 @@
+package org.openmrs.module.fhir2.api.translators.impl;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Condition;
+import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.IntegerType;
+import org.hl7.fhir.r4.model.StringType;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openmrs.Diagnosis;
+import org.openmrs.ConditionVerificationStatus;
+import org.openmrs.module.fhir2.api.translators.ConceptTranslator;
+import org.openmrs.module.fhir2.api.translators.EncounterReferenceTranslator;
+import org.openmrs.module.fhir2.api.translators.PatientReferenceTranslator;
+import org.openmrs.module.fhir2.api.translators.PractitionerReferenceTranslator;
+import org.openmrs.User;
+import org.openmrs.Encounter;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DiagnosisTranslatorImplTest {
+
+    @Mock
+    private PatientReferenceTranslator patientReferenceTranslator;
+    @Mock
+    private EncounterReferenceTranslator<Encounter> encounterReferenceTranslator;
+    @Mock
+    private PractitionerReferenceTranslator<User> practitionerReferenceTranslator;
+    @Mock
+    private ConceptTranslator conceptTranslator;
+
+    private DiagnosisTranslatorImpl translator;
+
+    @Before
+    public void setup() {
+        translator = new DiagnosisTranslatorImpl();
+        translator.setPatientReferenceTranslator(patientReferenceTranslator);
+        translator.setEncounterReferenceTranslator(encounterReferenceTranslator);
+        translator.setPractitionerReferenceTranslator(practitionerReferenceTranslator);
+        translator.setConceptTranslator(conceptTranslator);
+        when(practitionerReferenceTranslator.toFhirResource(isNull())).thenReturn(null);
+    }
+
+    @Test
+    public void toFhirResource_shouldAddRankAndCertaintyExtensions() {
+        Diagnosis diagnosis = new Diagnosis();
+        diagnosis.setUuid("diag-uuid");
+        diagnosis.setRank(1);
+        diagnosis.setCertainty(ConditionVerificationStatus.CONFIRMED);
+        diagnosis.setVoided(false);
+
+        Condition result = translator.toFhirResource(diagnosis);
+
+        Extension rank = result.getExtensionByUrl("http://openmrs.org/fhir/StructureDefinition/diagnosis-rank");
+        assertThat(rank, notNullValue());
+        assertThat(((IntegerType) rank.getValue()).getValue(), equalTo(1));
+
+        Extension certainty = result.getExtensionByUrl("http://openmrs.org/fhir/StructureDefinition/diagnosis-certainty");
+        assertThat(certainty, notNullValue());
+        assertThat(((StringType) certainty.getValue()).asStringValue(), equalTo(ConditionVerificationStatus.CONFIRMED.toString()));
+    }
+
+    @Test
+    public void toOpenmrsType_shouldMapVerificationStatusToCertainty() {
+        Condition condition = new Condition();
+        CodeableConcept verification = new CodeableConcept();
+        verification.addCoding(new Coding().setSystem("http://terminology.hl7.org/CodeSystem/condition-ver-status").setCode("provisional"));
+        condition.setVerificationStatus(verification);
+
+        Diagnosis result = translator.toOpenmrsType(condition);
+        assertThat(result.getCertainty(), equalTo(ConditionVerificationStatus.PROVISIONAL));
+    }
+}

--- a/api/src/test/java/org/openmrs/module/fhir2/api/util/FhirUtilsTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/util/FhirUtilsTest.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Condition;
+import org.hl7.fhir.r4.model.Reference;
 import org.junit.Test;
 
 public class FhirUtilsTest {
@@ -36,12 +37,36 @@ public class FhirUtilsTest {
 	}
 	
 	@Test
-	public void getOpenmrsConditionType_shouldDefaultToCondition() {
+        public void getOpenmrsConditionType_shouldDefaultToCondition() {
 		Condition condition = new Condition();
 		
 		Optional<FhirUtils.OpenmrsConditionType> result = FhirUtils.getOpenmrsConditionType(condition);
 		
 		assertThat(result.isPresent(), equalTo(true));
-		assertThat(result.get(), equalTo(FhirUtils.OpenmrsConditionType.CONDITION));
-	}
+                assertThat(result.get(), equalTo(FhirUtils.OpenmrsConditionType.CONDITION));
+        }
+
+        @Test
+        public void referenceToType_shouldExtractType() {
+                Optional<String> result = FhirUtils.referenceToType("Patient/123");
+                assertThat(result.isPresent(), equalTo(true));
+                assertThat(result.get(), equalTo("Patient"));
+        }
+
+        @Test
+        public void referenceToId_shouldExtractId() {
+                Optional<String> result = FhirUtils.referenceToId("http://example.com/Condition/abc/_history/1");
+                assertThat(result.isPresent(), equalTo(true));
+                assertThat(result.get(), equalTo("abc"));
+        }
+
+        @Test
+        public void getReferenceType_shouldPreferTypeField() {
+                org.hl7.fhir.r4.model.Reference reference = new org.hl7.fhir.r4.model.Reference();
+                reference.setType("Observation");
+                Optional<String> result = FhirUtils.getReferenceType(reference);
+                assertThat(result.isPresent(), equalTo(true));
+                assertThat(result.get(), equalTo("Observation"));
+        }
+
 }


### PR DESCRIPTION
## Summary
- add new Diagnosis translator tests
- add Diagnosis service test
- expand Condition service tests for diagnosis path
- extend diagnosis DAO tests
- add more utilities tests
- fix misplaced closing braces in unit tests

## Testing
- `mvn -q -DskipITs=true test` *(fails: Failed to read artifact descriptor for maven-openmrs-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6881c4df4574832482604f5869577949